### PR TITLE
backward sel in select_comb

### DIFF
--- a/R/R6_classes.R
+++ b/R/R6_classes.R
@@ -552,7 +552,7 @@ Selector <- R6::R6Class("Selector",
                 }
 
       
-      steps<-MASS::stepAIC(model,direction="both",trace=0,scope=scope)
+      steps<-MASS::stepAIC(model,direction="backward",trace=0,scope=scope)
       self$model<-steps
       if (length(self$model$coefficients)==1)
                return()


### PR DESCRIPTION
Original version in the article include a bacward selection based on AIC. 
Actually it is based on step, but it shoould be equivalent to stepAIC